### PR TITLE
Fix invalid GitHub watched repo URL

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -53,7 +53,7 @@ class GitHub {
             "unread": `${GitHub.SITE_URI}notifications`,
             "all": `${GitHub.SITE_URI}notifications?all=1`,
             "participating": `${GitHub.SITE_URI}notifications/participating`,
-            "watched": `${GitHub.SITE_URI}watched`
+            "watched": `${GitHub.SITE_URI}watching`
         };
     }
 


### PR DESCRIPTION
Watched repository URL is ✔️ https://github.com/watching not ❌ https://github.com/watched