### PR TITLE
Update GitHub participating notification URL

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -50,7 +50,7 @@ class GitHub {
             "index": GitHub.SITE_URI,
             "unread": `${GitHub.SITE_URI}notifications?query=is%3Aunread`,
             "all": `${GitHub.SITE_URI}notifications?query=`,
-            "participating": `${GitHub.SITE_URI}notifications/participating`,
+            "participating": `${GitHub.SITE_URI}notifications?query=reason%3Aparticipating`,
             "watched": `${GitHub.SITE_URI}watching`
         };
     }


### PR DESCRIPTION
GitHub had updated the URL from https://github.com/notifications/participating to https://github.com/notifications?query=reason%3Aparticipating with http permanent 301 redirect for a while, should update it to save a redirection, and in case the redirection may be turned off, the old URL totally deprecated in the future.